### PR TITLE
feat: Make header visible on main page

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -78,9 +78,12 @@ body {
   padding: 0;
 }
 
-/* Header - Hidden */
+/* Header */
 header {
-  display: none;
+  padding: 1.5rem 2rem;
+  text-align: center;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border-color);
 }
 
 header h1 {


### PR DESCRIPTION
Display 'Course Materials Assistant' header that was previously hidden.

Updated CSS to show header with proper styling while preserving the theme toggle button functionality.

Fixes #2

Generated with [Claude Code](https://claude.ai/code)